### PR TITLE
Remove mt5 files from gitattributes. Fixes #89

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *.mqh linguist-detectable=false
-*.mq5 linguist-detectable=false
+*.mq5 linguist-detectable=true
 *.java linguist-detectable=true


### PR DESCRIPTION
Remove mt5 files from gitattributes. Fixes #89